### PR TITLE
修复Firefox 44下不能添加规则订阅的问题

### DIFF
--- a/chrome/content/ui/tip_subscriptions.js
+++ b/chrome/content/ui/tip_subscriptions.js
@@ -23,13 +23,13 @@
  *
  * ***** END LICENSE BLOCK ***** */
 
-let autoAdd;
-let result;
-let defaultLabel;
-let menupop;
-let selectedId;
-let E = function(id) { return document.getElementById(id); };
-let cE = function(tag) { return document.createElementNS(
+var autoAdd;
+var result;
+var defaultLabel;
+var menupop;
+var selectedId;
+var E = function(id) { return document.getElementById(id); };
+var cE = function(tag) { return document.createElementNS(
         "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul", tag); };
 
 function init()


### PR DESCRIPTION
firefox 44下不能添加规则订阅了

调试后发现 /chrome/content/ui/tip_subscriptions.js
报错：redeclaration of non-configurable global property E

根据这个说明，https://bugzilla.mozilla.org/show_bug.cgi?id=1209777
change all top-level lets and consts to vars.

修改后经测试，可以修复问题
